### PR TITLE
fix: Add gitattributes for lf line endings on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Signed-off-by: Alex Harken <alexander.harken@aa.com>