### PR TITLE
prevents hero from cutting  off faces on  wide screens

### DIFF
--- a/ui/src/components/Hero/_hero.scss
+++ b/ui/src/components/Hero/_hero.scss
@@ -192,6 +192,7 @@
   height: max-content;
   object-fit: cover;
   opacity: 0.35;
+  object-position: top;
 }
 
 .hero__heading {


### PR DESCRIPTION
Contributes to #230 

## What did you do?
Added  `object-position: top` to the `.hero__image` in `_hero.scss`

## Why did you do it?
#230 identified a layout problem on wide screens where the hero was cutting off faces. The root cause is due to the `object-fit: cover` rule and the deafult behavior for image scaling and positioning. Setting `object-position: top` maintains the scaling behavior but positions the image so that most faces won't get cut off.

I considered changing the `object-fit` to `contain` however that dramatically changes the aesthetic by loosing the full-bleed look.

## How have you tested it?
Tested in the browser, on a 15" Mac Book Pro with a resolution of 1920 x 1200 and zoomed out the browser content to render ~2800px wide. Images seem to hold up nicely in this range w/out too much cutting off. 

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [x] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [x] Fixes entire issue
- [ ] Partial fix for issue
