### PR TITLE
Updates old link in PR readme

### DIFF
--- a/contributing/PULL-REQUESTS.md
+++ b/contributing/PULL-REQUESTS.md
@@ -239,7 +239,7 @@ There are a number of more advanced mechanisms for managing commits using
 Feel free to post a comment in the Pull Request to ping reviewers if you are
 awaiting an answer on something. If you encounter words or acronyms that
 seem unfamiliar, refer to this
-[glossary](https://sites.google.com/a/chromium.org/dev/glossary).
+[glossary](https://chromium.googlesource.com/chromiumos/docs/+/HEAD/glossary.md).
 
 #### Approval and Request Changes Workflow
 


### PR DESCRIPTION
Contributes to # (add issue number here. i.e. `#302`)

## What did you do?
Updated glossary link in Step 9.
## Why did you do it?
The link pointed to a redirect page.
## How have you tested it?
My forked version of the readme goes directly to the updated glossary.
## Were docs updated if needed?

- [ ] No
- [x] Yes
- [ ] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [x] Fixes entire issue
- [ ] Partial fix for issue
