### PR TITLE
change lint to use yarn ci-format

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run unit tests
         run: yarn run test:unit
       - name: Checkout code format
-        run: yarn run lint
+        run: yarn ci-format
       - name: Simulate production build
         run: yarn build


### PR DESCRIPTION
Contributes to # (add issue number here. i.e. `#302`)
#168 

## What did you do?
Changed "yarn run lint" to "yarn ci-format" in build-ui.yml

## Why did you do it?
to run ci-format

## How have you tested it?
Ran yarn ci-format in the services dir to note any errors from ci-format given than "yarn run lint" is already being run. Not sure if there's a better way to test the hook part since it needs a PR.

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [ X] N/A

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new console logs
- [X] Fixes entire issue
- [ ] Partial fix for issue
