### PR TITLE
Fix midterm dates

### DIFF
--- a/ui/src/api/dateFormatter.js
+++ b/ui/src/api/dateFormatter.js
@@ -61,4 +61,18 @@ export default {
     }
     return dateStr;
   },
+
+  /**
+   * Is date in the past?
+   * @param dateStr {string} Like 'MM/dd/yy'
+   * @returns {boolean}
+   */
+  tooLate(dateStr) {
+    try {
+      const dt = DateTime.fromFormat(dateStr, 'MM/dd/yy');
+      return DateTime.now().toMillis() > dt.toMillis();
+    } catch (e) {
+      return false;
+    }
+  },
 };

--- a/ui/src/data/usa-2022-midterms-info.json
+++ b/ui/src/data/usa-2022-midterms-info.json
@@ -2888,8 +2888,9 @@
       "id_explainer": "ID is required when applying for an absentee ballot.",
       "id_link": "https://www.ncsbe.gov/voting/vote-mail/detailed-instructions-vote-mail#1-request-ballot",
       "dropoff": true,
-      "request_deadline": "TBD",
-      "return_deadline": "TBD",
+      "return_deadline": "11/08/2022",
+      "request_deadline": "11/01/2022",
+
       "request_link": "https://s3.amazonaws.com/dl.ncsbe.gov/Forms/English-Fillable-2022-Absentee-Ballot-Request-Form.pdf",
       "track_link": "https://vt.ncsbe.gov/RegLkup/",
       "more_link": "https://www.ncsbe.gov/voting/vote-mail"
@@ -3043,7 +3044,7 @@
       "id_explainer": "ID is required when requesting an absentee ballot.",
       "id_link": "https://www.ohiosos.gov/elections/voters/absentee-voting/",
       "dropoff": true,
-      "request_deadline": "TBD",
+      "request_deadline": "11/05/2022",
       "return_deadline": "11/07/2022",
       "request_link": "https://www.ohiosos.gov/elections/voters/absentee-ballot/",
       "track_link": "https://www.ohiosos.gov/elections/voters/toolkit/ballot-tracking/",

--- a/ui/src/views/JourneyPage/EarlyVoting.vue
+++ b/ui/src/views/JourneyPage/EarlyVoting.vue
@@ -208,6 +208,9 @@ export default {
     votingAddress() {
       this.addressValue = this.votingAddress;
     },
+    filteredElections() {
+      if (this.filteredElections?.length === 1) this.electionId = this.filteredElections[0].id;
+    },
   },
   computed: {
     ...mapState({

--- a/ui/src/views/JourneyPage/JourneyPage.vue
+++ b/ui/src/views/JourneyPage/JourneyPage.vue
@@ -87,8 +87,8 @@ export default {
       if (this.absentee && this.which === 'absentee') this.which = 'get-informed';
     },
   },
-  created() {
-    this.$store.dispatch('getApproxLocation');
+  async created() {
+    await this.$store.dispatch('getApproxLocation');
     const regTooLate = dateFormatter.tooLate(this.info?.register?.deadline_in_person);
     const skipRegistration = this.registered || regTooLate;
     const absenteeTooLate = dateFormatter.tooLate(this.info?.mail_in?.request_deadline);

--- a/ui/src/views/JourneyPage/LocationList.vue
+++ b/ui/src/views/JourneyPage/LocationList.vue
@@ -6,7 +6,6 @@
         <cv-list>
           <cv-list-item v-for="(item, index) in earlyVoteSites" :key="index">
             <span class="loc-name">{{ item.address.locationName }}</span>
-            <span v-if="item.pollingHours" class="loc-name">{{ item.pollingHours }}</span>
 
             <span v-if="item.address.line1" class="loc-line">{{ item.address.line1 }}</span>
             <span v-if="item.address.line2" class="loc-line">{{ item.address.line2 }}</span>
@@ -15,9 +14,17 @@
             <span v-if="item.address.state" class="loc-state">
               {{ item.address.state }}
             </span>
-            <cv-link :href="directionsLink(item)" target="_blank">
-              {{ $t('mapDirections') }}
-            </cv-link>
+            <div>
+              <cv-link :href="directionsLink(item)" target="_blank">
+                <map-icon style="color: #0f62fe" />
+                <span class="location__directions">{{ $t('mapDirections') }}</span>
+              </cv-link>
+            </div>
+
+            <!-- hours -->
+            <div v-for="(h, hi) in formatHours(item.pollingHours)" :key="`${item.address}-h${hi}`">
+              <span class="loc-line">{{ h }}</span>
+            </div>
           </cv-list-item>
         </cv-list>
       </template>
@@ -28,8 +35,6 @@
         <cv-list>
           <cv-list-item v-for="(item, index) in pollingLocations" :key="index">
             <span class="loc-name">{{ item.address.locationName }}</span>
-            <span v-if="item.pollingHours" class="loc-name">{{ item.pollingHours }}</span>
-
             <span v-if="item.address.line1" class="loc-line">{{ item.address.line1 }}</span>
             <span v-if="item.address.line2" class="loc-line">{{ item.address.line2 }}</span>
             <span v-if="item.address.line3" class="loc-line">{{ item.address.line3 }}</span>
@@ -37,9 +42,17 @@
             <span v-if="item.address.state" class="loc-state">
               {{ item.address.state }}
             </span>
-            <cv-link :href="directionsLink(item)" target="_blank">
-              {{ $t('mapDirections') }}
-            </cv-link>
+            <div>
+              <cv-link :href="directionsLink(item)" target="_blank">
+                <map-icon style="color: #0f62fe" />
+                <span class="location__directions">{{ $t('mapDirections') }}</span>
+              </cv-link>
+            </div>
+
+            <!-- hours -->
+            <div v-for="(h, hi) in formatHours(item.pollingHours)" :key="`${item.address}-h${hi}`">
+              <span class="loc-line">{{ h }}</span>
+            </div>
           </cv-list-item>
         </cv-list>
       </template>
@@ -60,7 +73,8 @@
               {{ item.address.state }}
             </span>
             <cv-link :href="directionsLink(item)" target="_blank">
-              {{ $t('mapDirections') }}
+              <map-icon style="color: #0f62fe" />
+              <span class="location__directions">{{ $t('mapDirections') }}</span>
             </cv-link>
           </cv-list-item>
         </cv-list>
@@ -70,8 +84,11 @@
 </template>
 
 <script>
+import { Map32 } from '@carbon/icons-vue';
+
 export default {
   name: 'LocationList',
+  components: { MapIcon: Map32 },
   props: {
     votingData: {
       type: Object,
@@ -110,6 +127,9 @@ export default {
       const dir_link = 'https://www.google.com/maps/search/?api=1&query=' + escapedValue;
       return dir_link;
     },
+    formatHours(hours) {
+      return (hours || '').split('\n');
+    },
   },
 };
 </script>
@@ -118,4 +138,9 @@ export default {
 @import '@/styles/_theme.scss';
 @import 'carbon-components/scss/components/list/list';
 @import 'carbon-components/scss/components/accordion/accordion';
+.location {
+  &__directions {
+    margin-top: 0.75rem;
+  }
+}
 </style>


### PR DESCRIPTION
Contributes to #346 #357 #359 

## What did you do?
Fix "invalid date" found by @GeraldMit. There are more items in #357 s this only fixes that one basic issue. 

Also, reformatted hours as partial fix for #359 . More work could be done there.

Original midterm design in #346 calls for a different landing page depending on the date. Many places are past the date to register so they should land on request absentee ballot. After absentee ballot dat is past, user will land on get informed.

## Were docs updated if needed?

- [ ] No
- [ ] Yes
- [x] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [x] Fixes entire issue
- [x] Partial fix for issue
