### PR TITLE
Add responsiveness to Section.vue for layout issues

### DIFF
--- a/app/components/Home/Top/Section.vue
+++ b/app/components/Home/Top/Section.vue
@@ -10,12 +10,12 @@
           src="@/assets/images/five-fifths-voter.svg"
         />
       </div>
-      <div class="w-full p-3 text-white md:p-14">
+      <div class="w-full p-3 text-white md:p-14 lg:pt-0">
         <line-breaks
           :content="$t('landingTopTagline')"
           class="text-4xl md:text-6xl"
         />
-        <div class="pt-10 text-2xl md:max-w-96 md:pt-8 md:text-2xl">
+        <div class="pt-10 text-2xl md:max-w-96 md:pt-8 md:text-2xl lg:pt-1">
           {{ $t("landingTopDesc") }}
         </div>
       </div>


### PR DESCRIPTION
Contributes to #376 

## What did you do?
Fix padding and layout issues on large screens by adding a `lg:` tailwind classes 

## Description 
The initial layout looked something like this 
![image](https://github.com/Call-for-Code-for-Racial-Justice/Five-Fifths-Voter/assets/77844703/730f1110-85ca-4409-b64b-00780a2e5ada)
The initial tailwind classes had responsiveness for medium screens but not for large screens, I added a few classes to make them responsive for large screens to by adjusting the padding of the slogan part in the homepage.

I added a `lg:pt-0` class to the slogan div and `lg:pt-1` class to the inner slogan text to prevent overlapping of text.

The final layout looks like this on large screens
![image](https://github.com/Call-for-Code-for-Racial-Justice/Five-Fifths-Voter/assets/77844703/6e07ad7e-7a04-4220-a74c-f595b971b372)


#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
