### PR TITLE
feat: add NJ info

### DIFF
--- a/app/components/Journey/InformedDashboard.vue
+++ b/app/components/Journey/InformedDashboard.vue
@@ -126,8 +126,8 @@ const infoLinks = computed(() => [
               <div class="mb-4">
                 <h3 class="font-semibold text-ff-purple-01">In-Person Voting</h3>
                 <p><strong>ID Required for All Voters:</strong> {{ yesNoMaybe(election.voting.inPerson.idRequiredAllVoters) }}</p>
-                <p v-if="election.voting.inPerson.idInstructions"><strong>ID Instructions:</strong> {
-                  { election.voting.inPerson.idInstructions }}
+                <p v-if="election.voting.inPerson.idInstructions"><strong>ID Instructions:</strong>
+                  {{ election.voting.inPerson.idInstructions }}
                 </p>
                 <a :href="idInfoLink" target="_blank" class="text-blue-600 hover:underline">More information about IDs</a>
                 <p><strong>Election Day Hours:</strong>

--- a/app/components/Journey/RegisterDashboard.vue
+++ b/app/components/Journey/RegisterDashboard.vue
@@ -35,7 +35,7 @@ const registerOnlineLink = computed(() => content.value?.register?.online_link ?
 const registerByMailLink = computed(() => content.value?.register?.mail_link ?? "https://www.vote.org/absentee-ballot/");
 const changePartyLink = computed(() => content.value?.register?.change_party_link);
 const infoLink = computed(() => content.value?.register?.more_link ?? "https://www.usa.gov/voter-registration");
-const felonLink = computed(() => content.value?.register?.felonLink ?? "https://www.nationalvotinginprison.org/#state-laws");
+const felonLink = computed(() => content.value?.register?.felon_link ?? "https://www.nationalvotinginprison.org/#state-laws");
 
 function yesNoMaybe(val: string | boolean | undefined, yes: string, no: string, maybe: string | undefined) {
   if (val === true) return yes;

--- a/app/content/elections/nj/2025-gubernatorial.yml
+++ b/app/content/elections/nj/2025-gubernatorial.yml
@@ -1,0 +1,39 @@
+ocdId: "ocd-division/country:us/state:nj"
+date: "2025-11-04"
+description: "New Jersey Gubernatorial and General Assembly General Election"
+type: "general"
+website: "https://www.nj.gov/state/elections/vote.shtml"
+guidancePhase: "final"
+
+voting:
+  inPersonVotingAvailable: true
+  mailBallotsSentAutomatically: false
+  idUrl: https://www.nj.gov/state/elections/voter-registration.shtml
+  ballotpediaUrl: https://ballotpedia.org/New_Jersey_elections,_2025
+
+  early:
+    url: https://www.nj.gov/state/elections/vote-3-ways-to-vote.shtml
+    startDate: "2025-10-25"
+    endDate: "2025-11-02"
+    varies: true
+
+  byMail:
+    idInstructions: >
+      A current and valid Driver’s License or a non-driver Identification Card (ID card) issued by the New Jersey 
+      Motor Vehicle Commission (MVC) Your information will be provided to the MVC to validate identification, and to 
+      retrieve a copy of your digitized signature.
+    explainerUrl: https://www.nj.gov/state/elections/vote-3-ways-to-vote.shtml
+    deadline:
+      postmarkedOrReceived: "postmarked"
+      date: "2025-11-10"
+      ballotRequest:
+        postmarkedOrReceived: "received"
+        date: "2025-10-28"
+        description: "Your ballot request can also be made in person until Mon Nov 3, 2025"
+
+  inPerson:
+    idRequiredAllVoters: false
+    idInstructions: "If you have not previously voted in New Jersey, you need to provide ID the first time you vote."
+    electionDay:
+      opening: "6:00 AM"
+      closing: "8:00 PM"

--- a/app/content/procedures/NewJersey.yml
+++ b/app/content/procedures/NewJersey.yml
@@ -1,0 +1,27 @@
+region_code: nj
+region: New Jersey
+early_voting:
+  available: true
+  id_needed: false
+  more_link: https://www.nj.gov/state/elections/vote-3-ways-to-vote.shtml
+register:
+  formerlyIncarcerated: true
+  election_day: false
+  online: true
+  mail_link: https://www.nj.gov/state/elections/voter-registration.shtml
+  online_link: https://www.nj.gov/state/elections/voter-registration.shtml
+  change_party_link: https://www.state.nj.us/state/elections/voter-party-affiliation-declaration.shtml
+  under18: true
+  under18key: You can register to vote at 17 and vote at 18.
+  youth_link: https://www.nj.gov/state/elections/vote-students.shtml
+  felon_link: https://www.nj.gov/state/elections/voter-rights.shtml
+  check_link: https://voter.svrs.nj.gov/registration-check
+mail_in:
+  any_reason: true
+  without_notary: false
+  id_needed: true
+  dropoff: true
+  dropoff_link: https://www.nj.gov/state/elections/vote-by-mail.shtml
+  request_link: https://www.nj.gov/state/elections/vote-by-mail.shtml
+  track_link: http://trackmyballot.nj.gov/
+  more_link: https://www.nj.gov/state/elections/vote-by-mail.shtml


### PR DESCRIPTION
# Add New Jersey 2025 Gubernatorial Election Data and Fix Template Issues

## Changes
- Added configuration for New Jersey 2025 Gubernatorial and General Assembly General Election
- Added New Jersey state-wide voting procedures
- Fixed template formatting issues in InformedDashboard component
- Fixed felon link property name in RegisterDashboard component

## Details
### New Election Data
- Added `2025-gubernatorial.yml` for New Jersey with:
  - Election date: November 4, 2025
  - Early voting period: Oct 25 - Nov 2, 2025
  - Mail-in ballot deadlines and requirements
  - In-person voting details and ID requirements

### New State Procedures
- Added `NewJersey.yml` with comprehensive voting procedures including:
  - Early voting availability
  - Registration rules
  - Mail-in voting requirements
  - Ballot tracking and dropoff information

### Bug Fixes
1. Fixed template formatting in InformedDashboard.vue to properly display ID instructions without unwanted line breaks
2. Updated property name from `felonLink` to `felon_link` in RegisterDashboard.vue to match the expected format in content files

## Testing
Please verify:
- [x] New Jersey election information displays correctly in the dashboard
- [x] ID instructions formatting in InformedDashboard
- [x] Felon voting rights link works correctly in RegisterDashboard
- [x] All links in both YML files are accessible

## Related Documentation
- [New Jersey Division of Elections](https://www.nj.gov/state/elections/)
- [Vote By Mail Information](https://www.nj.gov/state/elections/vote-by-mail.shtml)