### PR TITLE
fix: data for NJ and GA

### DIFF
--- a/app/components/Journey/InformedDashboard.vue
+++ b/app/components/Journey/InformedDashboard.vue
@@ -25,7 +25,7 @@ const { data: election, status } = await useAsyncData<ContentProcedure>(
 
 const idInfoLink = computed(() => election.value?.voting?.idUrl);
 const infoLink = computed(() => election.value?.website ?? "https://www.vote.org/");
-const ballotpediaLink = computed(() => election.value?.ballotpediaUrl ?? "https://ballotpedia.org/Elections_calendar");
+const ballotpediaLink = computed(() => election.value?.voting?.ballotpediaUrl ?? "https://ballotpedia.org/Elections_calendar");
 
 function yesNoMaybe(val: string | boolean | undefined, yes: string = t("yes"), no: string = t("no"), maybe: string | undefined) {
   if (val === true) return yes;

--- a/app/components/Journey/RegisterDashboard.vue
+++ b/app/components/Journey/RegisterDashboard.vue
@@ -66,7 +66,7 @@ const infoLinks = computed(() => [
   },
   {
     title: "Voter registration info",
-    link: infoLink,
+    link: infoLink.value,
     icon: FileText,
   },
 ].filter(info => info.link));

--- a/app/components/Journey/VoteDashboard.vue
+++ b/app/components/Journey/VoteDashboard.vue
@@ -24,7 +24,7 @@ const { data: election, status } = await useAsyncData<ContentProcedure>(
 
 const idInfoLink = computed(() => election.value?.voting?.idUrl);
 const infoLink = computed(() => election.value?.website ?? "https://www.vote.org/");
-const ballotpediaLink = computed(() => election.value?.ballotpediaUrl ?? "https://ballotpedia.org/Elections_calendar");
+const ballotpediaLink = computed(() => election.value?.voting?.ballotpediaUrl ?? "https://ballotpedia.org/Elections_calendar");
 
 const infoLinks = computed(() => [
   {

--- a/app/content/elections/ga/2026-midterms.yml
+++ b/app/content/elections/ga/2026-midterms.yml
@@ -9,7 +9,7 @@ voting:
   inPersonVotingAvailable: true
   mailBallotsSentAutomatically: false
   idUrl: https://sos.ga.gov/page/georgia-voter-identification-requirements
-  ballotpediaUrl: https://ballotpedia.org/Elections_calendar
+  ballotpediaUrl: https://ballotpedia.org/Georgia_elections,_2026
 
   early:
     url: "https://sos.ga.gov/how-to-guide/how-guide-voting#Early%20Voting"

--- a/app/content/procedures/Georgia.yml
+++ b/app/content/procedures/Georgia.yml
@@ -16,6 +16,7 @@ register:
   youth_link: https://sos.ga.gov/how-to-guide/how-guide-registering-vote
   felon_link: https://gjp.org/voting/
   check_link: https://www.mvp.sos.ga.gov/MVP/mvp.do
+  more_link: https://sos.ga.gov/how-to-guide/how-guide-registering-vote
 mail_in:
   any_reason: true
   without_notary: true

--- a/app/content/procedures/NewJersey.yml
+++ b/app/content/procedures/NewJersey.yml
@@ -8,6 +8,7 @@ register:
   formerlyIncarcerated: true
   election_day: false
   online: true
+  more_link: https://www.nj.gov/state/elections/vote.shtml
   mail_link: https://www.nj.gov/state/elections/voter-registration.shtml
   online_link: https://www.nj.gov/state/elections/voter-registration.shtml
   change_party_link: https://www.state.nj.us/state/elections/voter-party-affiliation-declaration.shtml
@@ -18,10 +19,11 @@ register:
   check_link: https://voter.svrs.nj.gov/registration-check
 mail_in:
   any_reason: true
-  without_notary: false
+  without_notary: true
   id_needed: true
   dropoff: true
   dropoff_link: https://www.nj.gov/state/elections/vote-by-mail.shtml
   request_link: https://www.nj.gov/state/elections/vote-by-mail.shtml
   track_link: http://trackmyballot.nj.gov/
   more_link: https://www.nj.gov/state/elections/vote-by-mail.shtml
+  id_link: https://www.nj.gov/state/elections/vote-faq.shtml#faq2-12


### PR DESCRIPTION
# Fix Links and Update Election Configuration Data

## Changes
### Bug Fixes
1. Fixed Ballotpedia link access path in components:
   - Updated `InformedDashboard.vue` and `VoteDashboard.vue` to use `voting.ballotpediaUrl`
   - This aligns with the actual data structure in election YML files

2. Fixed link reference in RegisterDashboard:
   - Changed direct `infoLink` reference to `infoLink.value` to properly access the computed value

### Content Updates
1. Georgia Updates:
   - Added registration `more_link` to procedures
   - Updated Ballotpedia URL to point to specific 2026 Georgia elections page

2. New Jersey Configuration Updates:
   - Added missing registration `more_link`
   - Added mail-in ballot ID information link
   - Corrected `without_notary` setting to `true` for mail-in voting

## Testing
Please verify:
- [ ] Ballotpedia links work correctly in both Informed and Vote dashboards
- [ ] Registration info link works properly in the Register dashboard
- [ ] All new/updated links in Georgia and New Jersey configurations are accessible
- [ ] New Jersey mail-in voting information displays correctly

## Impact
These changes improve link accessibility and data accuracy, particularly for Georgia and New Jersey election information. No breaking changes are introduced, only enhancement of existing functionality and data correctness.