### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/certbot-schedule.yml
+++ b/.github/workflows/certbot-schedule.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Update site certificate
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -1,5 +1,7 @@
 name: End-to-end tests
 on: pull_request
+permissions:
+  contents: read
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,6 +2,11 @@ name: Greetings
 
 on: [pull_request, issues]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ibmcloud-codeengine.yml
+++ b/.github/workflows/ibmcloud-codeengine.yml
@@ -1,6 +1,9 @@
 # Deploy cloud - IBM Code Engine
 name: IBM Cloud - Deploy to Staging site
 
+permissions:
+  contents: read
+
 # Controls when the action will run.
 on:
   # Triggers the workflow on push for the main branch

--- a/.github/workflows/ibmcloud-s2p.yml
+++ b/.github/workflows/ibmcloud-s2p.yml
@@ -1,5 +1,7 @@
 # Deploy cloud - IBM Code Engine
 name: IBM Cloud - Staging to Production
+permissions:
+  contents: read
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,10 @@
 name: Mark stale issues and pull requests
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/Call-for-Code-for-Racial-Justice/Five-Fifths-Voter/security/code-scanning/12](https://github.com/Call-for-Code-for-Racial-Justice/Five-Fifths-Voter/security/code-scanning/12)

To resolve the issue, we will add a `permissions` block at the root of the workflow file. This will apply minimal permissions to the entire workflow. Since the workflow only requires reading the repository contents to perform actions like checkout and linting, we can set `contents: read` as the minimal permission. This ensures the workflow operates securely without unnecessary privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
