### PR TITLE
refactor: clean up scorecard UI and candidate issue links

### DIFF
--- a/app/components/Candidate/Scorecard.vue
+++ b/app/components/Candidate/Scorecard.vue
@@ -80,7 +80,6 @@ const clarityLabel = computed(() => {
       <div class="stat bg-base-100 shadow-sm rounded-box p-3">
         <div class="stat-title text-xs">Clarity</div>
         <div class="stat-value text-base leading-tight mt-1">{{ clarityLabel }}</div>
-        <div class="stat-desc text-xs truncate">{{ candidate.issues.clarity }}</div>
       </div>
       <div class="stat bg-base-100 shadow-sm rounded-box p-3">
         <div class="stat-title text-xs">Sources reviewed</div>
@@ -110,7 +109,6 @@ const clarityLabel = computed(() => {
 
     <!-- Footer -->
     <div class="text-xs text-base-content/40 px-1 space-y-1">
-      <div v-for="src in candidate.issues.sources_list" :key="src">{{ src }}</div>
       <div>Last updated: {{ candidate.issues.last_updated }}</div>
     </div>
   </div>

--- a/app/content/candidates/ga/democrat/lt-gov/josh-mclaurin.yaml
+++ b/app/content/candidates/ga/democrat/lt-gov/josh-mclaurin.yaml
@@ -25,8 +25,6 @@ issues:
   links:
     - label: "Campaign website"
       url: "https://www.joshmclaurin.com"
-    - label: "Priorities page"
-      url: "https://www.joshmclaurin.com/priorities"
     - label: "Atlanta Press Club debate"
       url: "https://youtu.be/AH_96yLFhd4?si=J4eW_qxc-rkVKrdn"
     - label: "11Alive extended interview"

--- a/app/content/candidates/ga/democrat/lt-gov/nabilah-parkes.yaml
+++ b/app/content/candidates/ga/democrat/lt-gov/nabilah-parkes.yaml
@@ -25,8 +25,6 @@ issues:
   links:
     - label: "Campaign website"
       url: "https://nabilahparkes.com"
-    - label: "Issues page"
-      url: "https://nabilahparkes.com/issues"
     - label: "Atlanta Press Club debate"
       url: "https://youtu.be/AH_96yLFhd4?si=J4eW_qxc-rkVKrdn"
     - label: "11Alive extended interview"

--- a/app/content/candidates/ga/republican/lt-gov/john-f-kennedy.yml
+++ b/app/content/candidates/ga/republican/lt-gov/john-f-kennedy.yml
@@ -24,8 +24,6 @@ issues:
   links:
     - label: "Campaign Website"
       url: "https://jfkforgeorgia.com/"
-    - label: "Georgia's Future (Issues Page)"
-      url: "https://jfkforgeorgia.com/georgias-future/"
     - label: "Trent Talks Interview (Video)"
       url: "https://youtu.be/9904pw3Ub2s?si=7RIBZxHRgRDug6N9"
     - label: "Atlanta Press Club Debate (Video)"

--- a/app/content/candidates/ga/republican/us-senate/derek-dooley.yml
+++ b/app/content/candidates/ga/republican/us-senate/derek-dooley.yml
@@ -24,10 +24,6 @@ issues:
   links:
     - label: "Campaign website"
       url: "https://www.dooleyforgeorgia.com/"
-    - label: "Priorities"
-      url: "https://www.dooleyforgeorgia.com/priorities"
-    - label: "The Georgia First Contract"
-      url: "https://www.dooleyforgeorgia.com/the-georgia-first-contract"
     - label: "Debate video (Atlanta Press Club, GPB)"
       url: "https://youtu.be/w1yaXTEBaWc?si=2LHGhZtFvOo5Iv0Z"
     - label: "Marietta Daily Journal Q&A, May 8, 2026"


### PR DESCRIPTION
## Summary
This PR refactors the `Candidate/Scorecard.vue` component to remove display of clarity and source lists, and removes outdated or redundant issue links from several candidate files.

## Changes
- Removed `candidate.issues.clarity` and `candidate.issues.sources_list` display from `Scorecard.vue`
- Removed redundant or broken issue links from multiple GA candidate YAML/YML files