### PR TITLE
fix: remove responsive text sizing from home page sections

### DIFF
--- a/app/components/Home/MissionSection.vue
+++ b/app/components/Home/MissionSection.vue
@@ -17,7 +17,7 @@ watchEffect(() => {
       class="ml-3 min-h-dvh short:min-h-0 pt-24 3xl:pt-56 snap-start short:snap-none"
   >
     <h1
-        class="mb-4 px-2 text-5xl sm:text-6xl 2xl:text-8xl"
+        class="mb-4 px-2 text-5xl font-bold"
     >
       {{ $t("landingPageMain") }}
     </h1>

--- a/app/components/Home/TopSection.vue
+++ b/app/components/Home/TopSection.vue
@@ -20,7 +20,7 @@ watchEffect(() => {
   >
     <div class="mb-16 w-full px-2 pt-0">
       <div
-          class="whitespace-break-spaces text-5xl sm:text-6xl 2xl:text-8xl"
+          class="whitespace-break-spaces text-5xl font-bold"
       >
         {{ $t('landingTopTagline') }}
       </div>

--- a/app/components/Home/ValuesSection.vue
+++ b/app/components/Home/ValuesSection.vue
@@ -20,7 +20,7 @@ watchEffect(() => {
       ref="section"
       class="ml-3 min-h-dvh short:min-h-0 pt-24 3xl:pt-56 snap-start short:snap-none short:mb-4"
   >
-    <h1 class="mb-4 px-2 text-5xl sm:text-6xl 2xl:text-8xl">
+    <h1 class="mb-4 px-2 text-5xl font-bold">
       {{ $t("appHeaderOurValues") }}
     </h1>
     <div class="space-y-3">


### PR DESCRIPTION
## Summary

Fixes text being too large on home page by removing responsive text sizing classes and adding font-bold styling.

- Remove `sm:text-6xl 2xl:text-8xl` responsive sizing from MissionSection, TopSection, and ValuesSection
- Add `font-bold` class to maintain visual hierarchy
- Standardizes text size to `text-5xl` across all sections