### PR TITLE
fix: adjust scroll spacing and button margins on home page

### DIFF
--- a/app/components/Home/MissionSection.vue
+++ b/app/components/Home/MissionSection.vue
@@ -14,7 +14,7 @@ watchEffect(() => {
 <template>
   <section
       id="mission"
-      class="ml-3 pt-24 3xl:pt-33"
+      class="ml-3 pt-32"
   >
     <h1
         class="mb-4 px-2 text-5xl font-bold"

--- a/app/components/Home/MissionSection.vue
+++ b/app/components/Home/MissionSection.vue
@@ -14,7 +14,7 @@ watchEffect(() => {
 <template>
   <section
       id="mission"
-      class="ml-3 min-h-dvh short:min-h-0 pt-24 3xl:pt-56 snap-start short:snap-none"
+      class="ml-3 pt-24 3xl:pt-33"
   >
     <h1
         class="mb-4 px-2 text-5xl font-bold"
@@ -23,12 +23,12 @@ watchEffect(() => {
     </h1>
     <div
         ref="section"
-        class="mb-8 whitespace-break-spaces px-2 leading-5 sm:text-lg 2xl:text-2xl">
+        class="whitespace-break-spaces px-2 leading-5 sm:text-lg 2xl:text-2xl">
       {{ $t("landingPageMission") }}
     </div>
     <button
         id="mission-journey-button"
-        class="btn btn-primary lg:btn-xl"
+        class="btn btn-primary lg:btn-xl mt-16"
         @click="navigateTo('/journey')"
     >
       <span class="md:text-lg">{{ $t("appHeaderVoterJourney") }}</span>

--- a/app/components/Home/TopSection.vue
+++ b/app/components/Home/TopSection.vue
@@ -16,9 +16,9 @@ watchEffect(() => {
   <section
       id="top"
       ref="section"
-      class="ml-3 min-h-dvh short:min-h-0 pt-24 md:pt-84 snap-start short:snap-none"
+      class="ml-3 pt-24 md:pt-84"
   >
-    <div class="mb-16 w-full px-2 pt-0">
+    <div class="w-full px-2 pt-0">
       <div
           class="whitespace-break-spaces text-5xl font-bold"
       >
@@ -32,7 +32,7 @@ watchEffect(() => {
     </div>
     <button
         id="top-journey-button"
-        class="btn btn-primary lg:btn-xl"
+        class="btn btn-primary lg:btn-xl mt-16"
         @click="navigateTo('/journey')"
     >
       <span class="md:text-lg">{{ $t("appHeaderVoterJourney") }}</span>

--- a/app/components/Home/ValuesSection.vue
+++ b/app/components/Home/ValuesSection.vue
@@ -18,7 +18,7 @@ watchEffect(() => {
   <section
       id="values"
       ref="section"
-      class="ml-3 min-h-dvh short:min-h-0 pt-24 3xl:pt-56 snap-start short:snap-none short:mb-4"
+      class="ml-3 pt-32 mb-16"
   >
     <h1 class="mb-4 px-2 text-5xl font-bold">
       {{ $t("appHeaderOurValues") }}
@@ -74,7 +74,7 @@ watchEffect(() => {
     </div>
     <button
         id="values-journey-button"
-        class="btn btn-primary lg:btn-xl mt-8"
+        class="btn btn-primary lg:btn-xl mt-16"
         @click="navigateTo('/journey')"
     >
       <span class="md:text-lg">{{ $t("appHeaderVoterJourney") }}</span>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -5,7 +5,7 @@ definePageMeta({
 
 useHead({
   htmlAttrs: {
-    class: "snap-y snap-mandatory scroll-smooth short:snap-none",
+    class: "snap-y scroll-smooth",
   },
 });
 </script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -5,7 +5,7 @@ definePageMeta({
 
 useHead({
   htmlAttrs: {
-    class: "snap-y scroll-smooth",
+    class: "scroll-smooth",
   },
 });
 </script>


### PR DESCRIPTION
Monday: TBD

## Summary

Fixes scroll spacing issues and improves button margins on the home page sections.

- Remove `min-h-dvh` and `short:min-h-0` classes from all home sections
- Remove `snap-start` and `short:snap-none` classes from home sections
- Add consistent margins to journey buttons (`mt-16`)
- Adjust padding on TopSection and ValuesSection
- Remove `snap-mandatory` from HTML class to fix scroll snapping issues